### PR TITLE
Roll back to Text widget to avoid uppercase text

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -33,7 +33,7 @@ Widget localized(Widget widget) {
 }
 
 class App extends StatelessWidget {
-  Brightness brightness = Brightness.light;
+  final Brightness brightness = Brightness.light;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -2,11 +2,10 @@ import 'dart:collection';
 
 import 'package:fimber/fimber_base.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
-import 'package:mobile/model/feed_message.dart';
 import 'package:mobile/api/feed_service.dart';
 import 'package:mobile/main.dart';
 import 'package:mobile/model/channel.dart';
+import 'package:mobile/model/feed_message.dart';
 import 'package:mobile/settings.dart';
 import 'package:mobile/ui_kit/channel.dart';
 import 'package:mobile/ui_kit/message_card_ui.dart';
@@ -85,7 +84,7 @@ class HomeScreenState extends State<HomeScreen> {
             );
           } else if (snapshot.hasError) {
             Fimber.d("Home - Snapshot has error");
-            return PlatformText("${snapshot.error}");
+            return Text("${snapshot.error}");
           }
 
           // By default, show a loading spinner.

--- a/lib/settings/channel.dart
+++ b/lib/settings/channel.dart
@@ -70,7 +70,7 @@ class _ChannelFormState extends State<ChannelForm> {
           Padding(
               padding: EdgeInsets.all(5.0),
               child: Column(children: [
-                PlatformText(
+                Text(
                   LocaleKeys.model_location.tr(),
                 ),
                 PlatformSwitchListTile(
@@ -92,7 +92,7 @@ class _ChannelFormState extends State<ChannelForm> {
           Padding(
             padding: EdgeInsets.all(4.0),
             child: Column(children: [
-              PlatformText(LocaleKeys.model_category.tr(),
+              Text(LocaleKeys.model_category.tr(),
                   style: Theme.of(context).textTheme.caption),
               MultiSelectFormField<ChannelCategory>(
                 elements: ChannelCategory.values,
@@ -183,7 +183,7 @@ class ChannelDialog extends StatelessWidget {
       actions: [
         PlatformButton(
           key: Key("cancel_channel"),
-          child: PlatformText(LocaleKeys.actions_cancel.tr()),
+          child: Text(LocaleKeys.actions_cancel.tr()),
           onPressed: () {
             Fimber.i("Cancel pressed");
 
@@ -192,7 +192,7 @@ class ChannelDialog extends StatelessWidget {
         ),
         PlatformButton(
             key: Key("submit_channel"),
-            child: PlatformText(submitText),
+            child: Text(submitText),
             onPressed: () {
               Fimber.i("Submit pressed");
               channelForm.submit();

--- a/lib/ui_kit/channel.dart
+++ b/lib/ui_kit/channel.dart
@@ -18,7 +18,7 @@ class LocationView extends StatelessWidget {
       var name = location.name;
       locationView = Padding(
           padding: EdgeInsets.all(5.0),
-          child: PlatformText(name != null ? name : "n/a"));
+          child: Text(name != null ? name : "n/a"));
     }
     return Container(
         child: Center(child: locationView), padding: EdgeInsets.all(3.0));
@@ -54,7 +54,7 @@ class ChannelCategoryView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    var text = PlatformText(
+    var text = Text(
       categoryLocalizationKey(category).tr(),
     );
     return Container(

--- a/lib/ui_kit/message_card_ui.dart
+++ b/lib/ui_kit/message_card_ui.dart
@@ -1,10 +1,9 @@
-import 'package:fimber/fimber.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
 
 class MessageCardUi extends StatelessWidget {
   final String identifier;
   final String description;
+
   const MessageCardUi({Key key, this.identifier, this.description})
       : super(key: key);
 
@@ -24,8 +23,8 @@ class MessageCardUi extends StatelessWidget {
                 size: MediaQuery.of(context).size.height * 0.06,
                 color: Colors.orangeAccent[200],
               ),
-              title: PlatformText(this.identifier),
-              subtitle: PlatformText(this.description),
+              title: Text(this.identifier),
+              subtitle: Text(this.description),
             ),
           ],
         ),

--- a/lib/ui_kit/platform/select.dart
+++ b/lib/ui_kit/platform/select.dart
@@ -1,6 +1,5 @@
 import 'dart:collection';
 
-import 'package:easy_localization/easy_localization.dart';
 import 'package:fimber/fimber_base.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
@@ -126,8 +125,8 @@ class PlatformSelectListTile extends PlatformWidgetBase<Widget, Widget> {
           child: Row(
             mainAxisAlignment: MainAxisAlignment.start,
             children: [
-              PlatformText(
-                this.label.tr(),
+              Text(
+                this.label,
               ),
               Spacer(),
               Container(
@@ -152,7 +151,7 @@ class PlatformSelectListTile extends PlatformWidgetBase<Widget, Widget> {
     return Row(
       mainAxisAlignment: MainAxisAlignment.end,
       children: [
-        PlatformText(this.label.tr()),
+        Text(this.label),
         Checkbox(
           key: getStateKey(),
           value: value,

--- a/lib/ui_kit/platform/switch.dart
+++ b/lib/ui_kit/platform/switch.dart
@@ -30,7 +30,7 @@ class PlatformSwitchListTile extends PlatformWidgetBase<Widget, Widget> {
   _wrap(Widget child) {
     return Row(
       mainAxisAlignment: MainAxisAlignment.end,
-      children: [PlatformText(this.label.tr()), child],
+      children: [Text(this.label.tr()), child],
     );
   }
 

--- a/lib/ui_kit/settings.dart
+++ b/lib/ui_kit/settings.dart
@@ -1,7 +1,6 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
 
 class HeadingItem {
   final String heading;
@@ -9,7 +8,7 @@ class HeadingItem {
   HeadingItem(this.heading);
 
   Widget build(BuildContext context) {
-    final child = PlatformText(
+    final child = Text(
       heading.tr(),
       style: Theme.of(context).textTheme.headline5,
     );
@@ -27,7 +26,7 @@ class AlertItem {
   AlertItem(this.message);
 
   Widget build(BuildContext context) {
-    final child = PlatformText(
+    final child = Text(
       message.tr(),
       style: Theme.of(context).textTheme.headline6,
     );


### PR DESCRIPTION
According to https://github.com/stryder-dev/flutter_platform_widgets/issues/62 `PlatformText` should only be used if uppercase text is required on Material.